### PR TITLE
Bump ejs + js-yaml; release 2.0.51 (supersedes Dependabot #6, #7)

### DIFF
--- a/oauth2example/package.json
+++ b/oauth2example/package.json
@@ -14,7 +14,7 @@
     "body-parser": "^1.13.3",
     "cookie-parser": "^1.3.5",
     "csrf": "^3.0.6",
-    "ejs": "3.1.7",
+    "ejs": "3.1.10",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "node-quickbooks": "2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pncit/node-quickbooks",
-  "version": "2.0.50",
+  "version": "2.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pncit/node-quickbooks",
-      "version": "2.0.50",
+      "version": "2.0.51",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.13.2",
@@ -923,10 +923,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pncit/node-quickbooks",
-  "version": "2.0.50",
+  "version": "2.0.51",
   "description": "node.js client for Intuit's IPP QuickBooks V3 API.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Consolidates the two open Dependabot PRs into a single release so publishing runs cleanly (a no-bump merge would conflict with the already-published 2.0.50).

- **ejs** 3.1.7 → 3.1.10 in `oauth2example/package.json` (supersedes #6; ejs security fix)
- **js-yaml** 4.1.0 → 4.2.0 in `package-lock.json` (supersedes #7; transitive via mocha)
- **version** 2.0.50 → 2.0.51

Neither dependency ships in the published tarball (`files` = `index.js` + `index.d.ts`), so this is a maintenance release with identical shipped code. On merge, CI publishes 2.0.51 via OIDC and Dependabot auto-closes #6/#7 as superseded.

Closes #6
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)